### PR TITLE
Support different branch names

### DIFF
--- a/config_reader.go
+++ b/config_reader.go
@@ -4,18 +4,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"git-notes/internal/types"
 	"io/ioutil"
 )
 
 const defaultBranch = "master"
 
-type Repo struct {
-	Path   string
-	Branch string
-}
-
 type Config struct {
-	Repos []Repo
+	Repos []types.Repo
 }
 
 type ConfigReader interface {
@@ -44,7 +40,7 @@ func (c *JsonConfigReader) Read(path string) (*Config, error) {
 		for _, val := range rec {
 			switch val := val.(type) {
 			case string:
-				repo := Repo{Path: val, Branch: defaultBranch}
+				repo := types.Repo{Path: val, Branch: defaultBranch}
 				config.Repos = append(config.Repos, repo)
 			case map[string]interface{}:
 				rpath, found := val["path"]
@@ -55,7 +51,7 @@ func (c *JsonConfigReader) Read(path string) (*Config, error) {
 				if !found {
 					return nil, fmt.Errorf("Unable to read repo branch from %v", val)
 				}
-				repo := Repo{Path: rpath.(string), Branch: branch.(string)}
+				repo := types.Repo{Path: rpath.(string), Branch: branch.(string)}
 				config.Repos = append(config.Repos, repo)
 			default:
 				return nil, fmt.Errorf("Unexpected type %T in %v", val, val)

--- a/config_reader.go
+++ b/config_reader.go
@@ -2,28 +2,68 @@ package main
 
 import (
 	"encoding/json"
-	"os"
+	"errors"
+	"fmt"
+	"io/ioutil"
 )
 
+const defaultBranch = "master"
+
+type Repo struct {
+	Path   string
+	Branch string
+}
+
 type Config struct {
-	Repos []string `json:"Repos"`
+	Repos []Repo
 }
 
 type ConfigReader interface {
 	Read(path string) (*Config, error)
 }
 
-type JsonConfigReader struct {}
+type JsonConfigReader struct{}
 
 func (c *JsonConfigReader) Read(path string) (*Config, error) {
-	file, err := os.Open(path)
-	if err != nil {  return nil, err }
+	bytes, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var doc map[string]interface{}
+	err = json.Unmarshal(bytes, &doc)
+	if err != nil {
+		return nil, err
+	}
 
-	decoder := json.NewDecoder(file)
-
+	repos, found := doc["repos"]
+	if !found {
+		return nil, errors.New("Unable to read repos list from " + path)
+	}
 	var config Config
-	err = decoder.Decode(&config)
-	if err != nil {  return nil, err }
+	if rec, ok := repos.([]interface{}); ok {
+		for _, val := range rec {
+			switch val := val.(type) {
+			case string:
+				repo := Repo{Path: val, Branch: defaultBranch}
+				config.Repos = append(config.Repos, repo)
+			case map[string]interface{}:
+				rpath, found := val["path"]
+				if !found {
+					return nil, fmt.Errorf("Unable to read repo path from %v", val)
+				}
+				branch, found := val["branch"]
+				if !found {
+					return nil, fmt.Errorf("Unable to read repo branch from %v", val)
+				}
+				repo := Repo{Path: rpath.(string), Branch: branch.(string)}
+				config.Repos = append(config.Repos, repo)
+			default:
+				return nil, fmt.Errorf("Unexpected type %T in %v", val, val)
+			}
+		}
+	} else {
+		return nil, errors.New("Config doesn't contain a repos list")
+	}
 
 	return &config, nil
 }

--- a/config_reader_test.go
+++ b/config_reader_test.go
@@ -1,8 +1,10 @@
 package main
 
 import (
-	"github.com/stretchr/testify/assert"
+	"git-notes/internal/types"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestJsonConfigReader_Read(t *testing.T) {
@@ -10,5 +12,5 @@ func TestJsonConfigReader_Read(t *testing.T) {
 	config, err := reader.Read("./git-notes.json.example")
 	assert.NoError(t, err)
 
-	assert.Equal(t, []string{"/Users/tanin/projects/personal-notes", "/Users/tanin/projects/another-personal-notes"}, config.Repos)
+	assert.Equal(t, []types.Repo{types.Repo{"/Users/ash/todos", "trunk"}, types.Repo{"/Users/ash/projects/personal-notes", "master"}}, config.Repos)
 }

--- a/git-notes.json.example
+++ b/git-notes.json.example
@@ -1,7 +1,9 @@
 {
   "repos": [
-    "/Users/tanin/projects/personal-notes",
-    "/Users/tanin/projects/another-personal-notes"
+    {
+      "path": "/Users/ash/todos",
+      "branch": "trunk"
+    },
+    "/Users/ash/projects/personal-notes"
   ]
 }
-

--- a/git.go
+++ b/git.go
@@ -74,8 +74,9 @@ func (g *GitCmd) IsDirty(repo types.Repo) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("unable to get status. Error: %v", err)
 	}
-
-	dirty := strings.TrimSpace(string(out)) != ""
+	out = strings.TrimSpace(string(out))
+	//fmt.Println("IsDirty(" + repo.Path + ") = [" + out + "]")
+	dirty := out != ""
 	return dirty, nil
 }
 
@@ -155,6 +156,9 @@ func GetStateAgainstRemote(repo types.Repo) (State, error) {
 	if err != nil {
 		return Error, fmt.Errorf("unable to fetch. Error: %v", err)
 	}
+
+	status = strings.TrimSpace(string(status))
+	//fmt.Println("GetStateAgainstRemote(" + repo.Path + ") = [" + status + "]")
 
 	return ParseStatusBranch(repo, status)
 }

--- a/git_test.go
+++ b/git_test.go
@@ -269,6 +269,7 @@ func TestGoGit_SyncOutOfSync(t *testing.T) {
 
 func makeConflict(t *testing.T, remote types.Repo) {
 	anotherLocal := test_helpers.SetupGitRepo("another_local", false)
+	defer test_helpers.CleanupRepo(anotherLocal.Path)
 	test_helpers.SetupRemote(anotherLocal, remote)
 	test_helpers.PerformCmd(t, anotherLocal, "git", "fetch")
 	test_helpers.PerformCmd(t, anotherLocal, "git", "checkout", anotherLocal.Branch)

--- a/git_test.go
+++ b/git_test.go
@@ -76,7 +76,7 @@ func TestGoGit_Rename(t *testing.T) {
 	performSync(t, repos.Local)
 	assertState(t, repos.Local, Sync)
 
-	assert.NoError(t, os.Rename(fmt.Sprintf("%s/%s", repos.Local, "test_name"), fmt.Sprintf("%s/%s", repos.Local, "TEST_NAME")))
+	assert.NoError(t, os.Rename(fmt.Sprintf("%s/%s", repos.Local.Path, "test_name"), fmt.Sprintf("%s/%s", repos.Local.Path, "TEST_NAME")))
 
 	assertState(t, repos.Local, Dirty)
 	performUpdate(t, repos.Local)
@@ -127,7 +127,7 @@ func TestGoGit_Deletion(t *testing.T) {
 	performSync(t, repos.Local)
 	assertState(t, repos.Local, Sync)
 
-	assert.NoError(t, os.Remove(fmt.Sprintf("%s/%s", repos.Local, "test.md")))
+	assert.NoError(t, os.Remove(fmt.Sprintf("%s/%s", repos.Local.Path, "test.md")))
 
 	assertState(t, repos.Local, Dirty)
 	performUpdate(t, repos.Local)

--- a/git_test.go
+++ b/git_test.go
@@ -165,7 +165,7 @@ func TestGoGit_UpdateSync(t *testing.T) {
 	test_helpers.WriteFile(t, repos.Local, "test.md", "TestContent")
 	test_helpers.PerformCmd(t, repos.Local, "git", "add", "--all")
 	test_helpers.PerformCmd(t, repos.Local, "git", "commit", "-m", "Test")
-	test_helpers.PerformCmd(t, repos.Local, "git", "push", "origin", "master", "-u")
+	test_helpers.PerformCmd(t, repos.Local, "git", "push", "origin", repos.Local.Branch, "-u")
 
 	assertState(t, repos.Local, Sync)
 	performUpdate(t, repos.Local)
@@ -179,7 +179,7 @@ func TestGoGit_UpdateOutOfSync(t *testing.T) {
 	test_helpers.WriteFile(t, repos.Local, "test.md", "TestContent")
 	test_helpers.PerformCmd(t, repos.Local, "git", "add", "--all")
 	test_helpers.PerformCmd(t, repos.Local, "git", "commit", "-m", "Test")
-	test_helpers.PerformCmd(t, repos.Local, "git", "push", "origin", "master", "-u")
+	test_helpers.PerformCmd(t, repos.Local, "git", "push", "origin", repos.Local.Branch, "-u")
 
 	makeConflict(t, repos.Remote)
 
@@ -195,7 +195,7 @@ func TestGoGit_UpdateFixConflict(t *testing.T) {
 	test_helpers.WriteFile(t, repos.Local, "test.md", "TestContent")
 	test_helpers.PerformCmd(t, repos.Local, "git", "add", "--all")
 	test_helpers.PerformCmd(t, repos.Local, "git", "commit", "-m", "Test local")
-	test_helpers.PerformCmd(t, repos.Local, "git", "push", "origin", "master", "-u")
+	test_helpers.PerformCmd(t, repos.Local, "git", "push", "origin", repos.Local.Branch, "-u")
 
 	makeConflict(t, repos.Remote)
 	assertState(t, repos.Local, OutOfSync)
@@ -244,7 +244,7 @@ func TestGoGit_SyncSync(t *testing.T) {
 	test_helpers.WriteFile(t, repos.Local, "test.md", "TestContent")
 	test_helpers.PerformCmd(t, repos.Local, "git", "add", "--all")
 	test_helpers.PerformCmd(t, repos.Local, "git", "commit", "-m", "Test")
-	test_helpers.PerformCmd(t, repos.Local, "git", "push", "origin", "master", "-u")
+	test_helpers.PerformCmd(t, repos.Local, "git", "push", "origin", repos.Local.Branch, "-u")
 
 	assertState(t, repos.Local, Sync)
 	performSync(t, repos.Local)
@@ -258,7 +258,7 @@ func TestGoGit_SyncOutOfSync(t *testing.T) {
 	test_helpers.WriteFile(t, repos.Local, "test.md", "TestContent")
 	test_helpers.PerformCmd(t, repos.Local, "git", "add", "--all")
 	test_helpers.PerformCmd(t, repos.Local, "git", "commit", "-m", "Test")
-	test_helpers.PerformCmd(t, repos.Local, "git", "push", "origin", "master", "-u")
+	test_helpers.PerformCmd(t, repos.Local, "git", "push", "origin", repos.Local.Branch, "-u")
 
 	makeConflict(t, repos.Remote)
 
@@ -271,7 +271,7 @@ func makeConflict(t *testing.T, remote types.Repo) {
 	anotherLocal := test_helpers.SetupGitRepo("another_local", false)
 	test_helpers.SetupRemote(anotherLocal, remote)
 	test_helpers.PerformCmd(t, anotherLocal, "git", "fetch")
-	test_helpers.PerformCmd(t, anotherLocal, "git", "checkout", "master")
+	test_helpers.PerformCmd(t, anotherLocal, "git", "checkout", anotherLocal.Branch)
 	test_helpers.WriteFile(t, anotherLocal, "test.md", "Cause conflict")
 	test_helpers.PerformCmd(t, anotherLocal, "git", "add", "--all")
 	test_helpers.PerformCmd(t, anotherLocal, "git", "commit", "-m", "Test Remote")
@@ -285,7 +285,7 @@ func TestGoGit_SyncFixConflict(t *testing.T) {
 	test_helpers.WriteFile(t, repos.Local, "test.md", "TestContent")
 	test_helpers.PerformCmd(t, repos.Local, "git", "add", "--all")
 	test_helpers.PerformCmd(t, repos.Local, "git", "commit", "-m", "Test local")
-	test_helpers.PerformCmd(t, repos.Local, "git", "push", "origin", "master", "-u")
+	test_helpers.PerformCmd(t, repos.Local, "git", "push", "origin", repos.Local.Branch, "-u")
 
 	makeConflict(t, repos.Remote)
 

--- a/git_test.go
+++ b/git_test.go
@@ -76,7 +76,7 @@ func TestGoGit_Rename(t *testing.T) {
 	performSync(t, repos.Local)
 	assertState(t, repos.Local, Sync)
 
-	assert.NoError(t, os.Rename(fmt.Sprintf("%s/%s", repos.Local.Path, "test_name"), fmt.Sprintf("%s/%s", repos.Local.Path, "TEST_NAME")))
+	assert.NoError(t, os.Rename(fmt.Sprintf("%s/%s", repos.Local.Path, "test_name"), fmt.Sprintf("%s/%s", repos.Local.Path, "test-name")))
 
 	assertState(t, repos.Local, Dirty)
 	performUpdate(t, repos.Local)

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,4 @@ module git-notes
 
 go 1.16
 
-require (
-	github.com/stretchr/testify v1.7.0
-	github.com/tanin47/git-notes v0.0.0-20191123193420-f1ef341555fa
-)
+require github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,6 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/tanin47/git-notes v0.0.0-20191123193420-f1ef341555fa h1:Hq8aeWocljvQVZPtTMo12dUNFpULdlWAuw6XZFVKpWY=
-github.com/tanin47/git-notes v0.0.0-20191123193420-f1ef341555fa/go.mod h1:m8Sb2ydPMF4WkHMubSDlEtil2T3pvhGItWUU65+QzAQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=

--- a/internal/test_helpers/repo.go
+++ b/internal/test_helpers/repo.go
@@ -43,6 +43,13 @@ func CleanupRepos(repos Repos) {
 	}
 }
 
+func CleanupConfig(configDir string) {
+	err := os.RemoveAll(configDir)
+	if err != nil {
+		log.Fatalf("Unable to remove %s. Error: %v", configDir, err)
+	}
+}
+
 func SetupGitRepo(tag string, bare bool) types.Repo {
 	path, err := ioutil.TempDir("", fmt.Sprintf("git_test_%s", tag))
 	if err != nil {
@@ -64,6 +71,13 @@ func SetupGitRepo(tag string, bare bool) types.Repo {
 	return types.Repo{
 		Path:   path,
 		Branch: "trunk",
+	}
+}
+
+func CleanupRepo(repoDir string) {
+	err := os.RemoveAll(repoDir)
+	if err != nil {
+		log.Fatalf("Unable to remove %s. Error: %v", repoDir, err)
 	}
 }
 

--- a/internal/test_helpers/repo.go
+++ b/internal/test_helpers/repo.go
@@ -49,7 +49,7 @@ func SetupGitRepo(tag string, bare bool) types.Repo {
 		log.Fatalf("Unable to create a temp dir for the Remote repo")
 	}
 
-	args := []string{"init"}
+	args := []string{"init", "--initial-branch", "trunk"}
 	if bare {
 		args = append(args, "--bare")
 	}

--- a/internal/test_helpers/repo.go
+++ b/internal/test_helpers/repo.go
@@ -2,18 +2,20 @@ package test_helpers
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
+	"git-notes/internal/types"
 	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type Repos struct {
-	Remote string
-	Local  string
+	Remote types.Repo
+	Local  types.Repo
 }
 
 func SetupRepos() Repos {
@@ -30,18 +32,18 @@ func SetupRepos() Repos {
 }
 
 func CleanupRepos(repos Repos) {
-	err := os.RemoveAll(repos.Remote)
+	err := os.RemoveAll(repos.Remote.Path)
 	if err != nil {
-		log.Fatalf("Unable to remove %s. Error: %v", repos.Remote, err)
+		log.Fatalf("Unable to remove %s. Error: %v", repos.Remote.Path, err)
 	}
 
-	err = os.RemoveAll(repos.Local)
+	err = os.RemoveAll(repos.Local.Path)
 	if err != nil {
-		log.Fatalf("Unable to remove %s. Error: %v", repos.Local, err)
+		log.Fatalf("Unable to remove %s. Error: %v", repos.Local.Path, err)
 	}
 }
 
-func SetupGitRepo(tag string, bare bool) string {
+func SetupGitRepo(tag string, bare bool) types.Repo {
 	path, err := ioutil.TempDir("", fmt.Sprintf("git_test_%s", tag))
 	if err != nil {
 		log.Fatalf("Unable to create a temp dir for the Remote repo")
@@ -59,31 +61,39 @@ func SetupGitRepo(tag string, bare bool) string {
 		log.Fatalf("Unable to init the repo. Path: %v, Error: %v", path, err)
 	}
 
-	return path
+	return types.Repo{
+		Path:   path,
+		Branch: "trunk",
+	}
 }
 
-func SetupRemote(local string, remote string) {
-	c := exec.Command("git", "remote", "add", "origin", remote)
+func SetupRemote(local types.Repo, remote types.Repo) {
+	c := exec.Command("git", "remote", "add", "origin", remote.Path)
 	c.Stderr = os.Stderr
 	c.Stdout = os.Stdout
-	c.Dir = local
+	c.Dir = local.Path
 	err := c.Run()
 	if err != nil {
 		log.Fatalf("Unable to add origin. Error: %v", err)
 	}
 }
 
-func WriteFile(t *testing.T, repoPath string, filePath string, content string) {
-	fullPath := fmt.Sprintf("%s/%s", repoPath, filePath)
+func WriteConfigFile(t *testing.T, path string, filePath string, content string) {
+	fullPath := fmt.Sprintf("%s/%s", path, filePath)
 	log.Printf("Write file: %v, content: %v", fullPath, content)
 	assert.NoError(t, ioutil.WriteFile(fullPath, []byte(content), 0644))
 }
 
+func WriteFile(t *testing.T, repo types.Repo, filePath string, content string) {
+	fullPath := fmt.Sprintf("%s/%s", repo.Path, filePath)
+	log.Printf("Write file: %v, content: %v", fullPath, content)
+	assert.NoError(t, ioutil.WriteFile(fullPath, []byte(content), 0644))
+}
 
-func PerformCmd(t *testing.T, path string, cmd string, args... string) {
+func PerformCmd(t *testing.T, repo types.Repo, cmd string, args ...string) {
 	log.Printf("Run cmd: %v", strings.Join(append([]string{cmd}, args...), " "))
 	c := exec.Command(cmd, args...)
-	c.Dir = path
+	c.Dir = repo.Path
 	c.Stdin = os.Stdin
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr

--- a/internal/types/repo.go
+++ b/internal/types/repo.go
@@ -1,0 +1,6 @@
+package types
+
+type Repo struct {
+	Path   string
+	Branch string
+}

--- a/main.go
+++ b/main.go
@@ -14,11 +14,11 @@ func main() {
 
 	var git = NewGoGit()
 	var watcher = GitWatcher{
-		git:     &git,
-		running: false,
-		checkInterval: 10 * time.Second,
+		git:                    &git,
+		running:                false,
+		checkInterval:          10 * time.Second,
 		delayBeforeFiringEvent: 2 * time.Second,
-		delayAfterFiringEvent: 5 * time.Second,
+		delayAfterFiringEvent:  5 * time.Second,
 	}
 	var configReader = JsonConfigReader{}
 	var gitRepoMonitor = GitRepoMonitor{
@@ -44,8 +44,7 @@ func Run(git Git, watcher Watcher, configReader ConfigReader, monitor PathMonito
 	}
 
 	fmt.Println(config)
-	for _, repoPath := range config.Repos {
-		monitor.StartMonitoring(repoPath, watcher, git)
+	for _, repo := range config.Repos {
+		monitor.StartMonitoring(repo, watcher, git)
 	}
 }
-

--- a/main_test.go
+++ b/main_test.go
@@ -2,12 +2,14 @@ package main
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"git-notes/internal/test_helpers"
+	"git-notes/internal/types"
 	"io/ioutil"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMainFunc(t *testing.T) {
@@ -21,7 +23,7 @@ func TestMainFunc(t *testing.T) {
 	configDir, err := ioutil.TempDir("", "git-notes-config-dir")
 	assert.NoError(t, err)
 
-	test_helpers.WriteFile(t, configDir, "git-notes.json", fmt.Sprintf(`{ "repos": [ "%s" ] }`, repos.Local))
+	test_helpers.WriteConfigFile(t, configDir, "git-notes.json", fmt.Sprintf(`{ "repos": [ "%s" ] }`, repos.Local))
 
 	oldArgs := os.Args
 	os.Args = []string{"app", fmt.Sprintf("%s/%s", configDir, "git-notes.json")}
@@ -41,7 +43,7 @@ func TestMainFunc(t *testing.T) {
 		state, err := git.GetState(repos.Local)
 		assert.NoError(t, err)
 		return state == Sync
-	}, 15 * time.Second, 1 * time.Second)
+	}, 15*time.Second, 1*time.Second)
 
 	test_helpers.WriteFile(t, repos.Local, "test.md", "TestContent2")
 
@@ -53,7 +55,7 @@ func TestMainFunc(t *testing.T) {
 		state, err := git.GetState(repos.Local)
 		assert.NoError(t, err)
 		return state == Sync
-	}, 15 * time.Second, 1 * time.Second)
+	}, 15*time.Second, 1*time.Second)
 
 	Running = false
 }
@@ -71,7 +73,7 @@ func TestRun(t *testing.T) {
 	Run(&git, &watcher, &configReader, &monitor)
 
 	assert.Equal(t, "some-git-notes.json", configReader.readPath)
-	assert.Equal(t, []string{"some-path", "some-path-2"}, monitor.startMonitorPaths)
+	assert.Equal(t, []types.Repo{types.Repo{"some-path", "trunk"}, types.Repo{"some-path-2", "master"}}, monitor.startMonitorRepos)
 }
 
 type MockConfigReader struct {
@@ -81,18 +83,18 @@ type MockConfigReader struct {
 func (m *MockConfigReader) Read(path string) (*Config, error) {
 	m.readPath = path
 	var config = &Config{
-		Repos: []string{"some-path", "some-path-2"},
+		Repos: []types.Repo{types.Repo{"some-path", "trunk"}, types.Repo{"some-path-2", "master"}},
 	}
 	return config, nil
 }
 
 type MockMonitor struct {
-	startMonitorPaths []string
+	startMonitorRepos []types.Repo
 }
 
-func (m *MockMonitor) StartMonitoring(repoPath string, watcher Watcher, git Git) {
-	m.startMonitorPaths = append(m.startMonitorPaths, repoPath)
+func (m *MockMonitor) StartMonitoring(repo types.Repo, watcher Watcher, git Git) {
+	m.startMonitorRepos = append(m.startMonitorRepos, repo)
 }
 
-func (m *MockMonitor) scheduleUpdate(repoPath string, channel chan string) {
+func (m *MockMonitor) scheduleUpdate(repo types.Repo, channel chan types.Repo) {
 }

--- a/main_test.go
+++ b/main_test.go
@@ -23,7 +23,7 @@ func TestMainFunc(t *testing.T) {
 	configDir, err := ioutil.TempDir("", "git-notes-config-dir")
 	assert.NoError(t, err)
 
-	test_helpers.WriteConfigFile(t, configDir, "git-notes.json", fmt.Sprintf(`{ "repos": [ "%s" ] }`, repos.Local))
+	test_helpers.WriteConfigFile(t, configDir, "git-notes.json", fmt.Sprintf(`{ "repos": [ { "path": "%s", "branch": "%s"} ] }`, repos.Local.Path, repos.Local.Branch))
 
 	oldArgs := os.Args
 	os.Args = []string{"app", fmt.Sprintf("%s/%s", configDir, "git-notes.json")}

--- a/main_test.go
+++ b/main_test.go
@@ -21,6 +21,7 @@ func TestMainFunc(t *testing.T) {
 	defer test_helpers.CleanupRepos(repos)
 
 	configDir, err := ioutil.TempDir("", "git-notes-config-dir")
+	defer test_helpers.CleanupConfig(configDir)
 	assert.NoError(t, err)
 
 	test_helpers.WriteConfigFile(t, configDir, "git-notes.json", fmt.Sprintf(`{ "repos": [ { "path": "%s", "branch": "%s"} ] }`, repos.Local.Path, repos.Local.Branch))

--- a/path_monitor.go
+++ b/path_monitor.go
@@ -1,28 +1,29 @@
 package main
 
 import (
+	"git-notes/internal/types"
 	"log"
 	"time"
 )
 
 type PathMonitor interface {
-	StartMonitoring(repo Repo, watcher Watcher, git Git)
-	scheduleUpdate(repo Repo, channel chan Repo)
+	StartMonitoring(repo types.Repo, watcher Watcher, git Git)
+	scheduleUpdate(repo types.Repo, channel chan types.Repo)
 }
 
 type GitRepoMonitor struct {
 	scheduledUpdateInterval time.Duration
 }
 
-func (g *GitRepoMonitor) scheduleUpdate(repo Repo, channel chan Repo) {
+func (g *GitRepoMonitor) scheduleUpdate(repo types.Repo, channel chan types.Repo) {
 	time.AfterFunc(g.scheduledUpdateInterval, func() {
 		channel <- repo
 		g.scheduleUpdate(repo, channel)
 	})
 }
 
-func (g *GitRepoMonitor) StartMonitoring(repo Repo, watcher Watcher, git Git) {
-	var channel = make(chan Repo)
+func (g *GitRepoMonitor) StartMonitoring(repo types.Repo, watcher Watcher, git Git) {
+	var channel = make(chan types.Repo)
 	err := git.Sync(repo)
 	if err != nil {
 		log.Printf("Syncing failed. Err: %v", err)

--- a/watcher.go
+++ b/watcher.go
@@ -1,12 +1,13 @@
 package main
 
 import (
+	"git-notes/internal/types"
 	"log"
 	"time"
 )
 
 type Watcher interface {
-	Watch(repo Repo, channel chan Repo)
+	Watch(repo types.Repo, channel chan types.Repo)
 }
 
 type GitWatcher struct {
@@ -21,7 +22,7 @@ func (f *GitWatcher) Stop() {
 	f.running = false
 }
 
-func (f *GitWatcher) Check(repo Repo, channel chan Repo) {
+func (f *GitWatcher) Check(repo types.Repo, channel chan types.Repo) {
 	dirty, err := f.git.IsDirty(repo)
 
 	if err != nil {
@@ -36,7 +37,7 @@ func (f *GitWatcher) Check(repo Repo, channel chan Repo) {
 	}
 }
 
-func (f *GitWatcher) Watch(repo Repo, channel chan Repo) {
+func (f *GitWatcher) Watch(repo types.Repo, channel chan types.Repo) {
 	f.running = true
 	go func() {
 		for f.running {

--- a/watcher.go
+++ b/watcher.go
@@ -6,23 +6,23 @@ import (
 )
 
 type Watcher interface {
-	Watch(path string, channel chan string)
+	Watch(repo Repo, channel chan Repo)
 }
 
 type GitWatcher struct {
-	git Git
-	running bool
-	checkInterval time.Duration
+	git                    Git
+	running                bool
+	checkInterval          time.Duration
 	delayBeforeFiringEvent time.Duration
-	delayAfterFiringEvent time.Duration
+	delayAfterFiringEvent  time.Duration
 }
 
 func (f *GitWatcher) Stop() {
 	f.running = false
 }
 
-func (f *GitWatcher) Check(path string, channel chan string) {
-	dirty, err := f.git.IsDirty(path)
+func (f *GitWatcher) Check(repo Repo, channel chan Repo) {
+	dirty, err := f.git.IsDirty(repo)
 
 	if err != nil {
 		log.Printf("Failed to get state. Error: %v", err)
@@ -31,17 +31,17 @@ func (f *GitWatcher) Check(path string, channel chan string) {
 	if dirty {
 		log.Printf("Changes have been detected.")
 		time.Sleep(f.delayBeforeFiringEvent)
-		channel <- path
+		channel <- repo
 		time.Sleep(f.delayAfterFiringEvent)
 	}
 }
 
-func (f *GitWatcher) Watch(path string, channel chan string) {
+func (f *GitWatcher) Watch(repo Repo, channel chan Repo) {
 	f.running = true
 	go func() {
 		for f.running {
 			time.Sleep(f.checkInterval)
-			f.Check(path, channel)
+			f.Check(repo, channel)
 		}
 	}()
 

--- a/watcher_test.go
+++ b/watcher_test.go
@@ -1,99 +1,101 @@
 package main
 
 import (
-	"github.com/stretchr/testify/assert"
 	"git-notes/internal/test_helpers"
+	"git-notes/internal/types"
 	"log"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type listener struct {
-	paths []string
+	repos []types.Repo
 }
 
-func setup() (*GitWatcher, *listener, string, chan string) {
-	var channel chan string = make(chan string)
+func setup() (*GitWatcher, *listener, types.Repo, chan types.Repo) {
+	var channel chan types.Repo = make(chan types.Repo)
 
-	var watcher = GitWatcher {
-		git: &GitCmd{},
-		running: false,
-		checkInterval: 10 * time.Millisecond,
+	var watcher = GitWatcher{
+		git:                    &GitCmd{},
+		running:                false,
+		checkInterval:          10 * time.Millisecond,
 		delayBeforeFiringEvent: 0,
-		delayAfterFiringEvent: 1 * time.Second,
+		delayAfterFiringEvent:  1 * time.Second,
 	}
 
-	var path = test_helpers.SetupGitRepo("watcher", false)
+	var repo = test_helpers.SetupGitRepo("watcher", false)
 
 	var listener listener
 
 	go func() {
 		for {
-			path = <- channel
-			listener.paths = append(listener.paths, path)
+			repo = <-channel
+			listener.repos = append(listener.repos, repo)
 		}
 	}()
 
-	return &watcher, &listener, path, channel
+	return &watcher, &listener, repo, channel
 }
 
-func cleanup(watcher *GitWatcher, path string) {
-	err := os.RemoveAll(path)
+func cleanup(watcher *GitWatcher, repo types.Repo) {
+	err := os.RemoveAll(repo.Path)
 	if err != nil {
-		log.Fatalf("Unable to remove %s. Error: %v", path, err)
+		log.Fatalf("Unable to remove %s. Error: %v", repo.Path, err)
 	}
 
 	watcher.Stop()
 }
 
-func commit(t *testing.T, path string) {
-	test_helpers.PerformCmd(t, path, "git", "add", "--all")
-	test_helpers.PerformCmd(t, path, "git", "commit", "-m", "Test")
+func commit(t *testing.T, repo types.Repo) {
+	test_helpers.PerformCmd(t, repo, "git", "add", "--all")
+	test_helpers.PerformCmd(t, repo, "git", "commit", "-m", "Test")
 }
 
 func TestGitWatcher_Watch(t *testing.T) {
-	var watcher, listener, path, channel = setup()
-	defer cleanup(watcher, path)
+	var watcher, listener, repo, channel = setup()
+	defer cleanup(watcher, repo)
 
-	watcher.Watch(path, channel)
+	watcher.Watch(repo, channel)
 
-	assert.Equal(t, 0, len(listener.paths))
+	assert.Equal(t, 0, len(listener.repos))
 
-	test_helpers.WriteFile(t, path, "test.md", "Watch")
+	test_helpers.WriteFile(t, repo, "test.md", "Watch")
 	time.Sleep(1 * time.Second)
-	assert.Greater(t, len(listener.paths), 0)
-	assert.Equal(t, path, listener.paths[0])
+	assert.Greater(t, len(listener.repos), 0)
+	assert.Equal(t, repo, listener.repos[0])
 }
 
 func TestGitWatcher_CreateAndModify(t *testing.T) {
-	var watcher, listener, path, channel = setup()
-	defer cleanup(watcher, path)
+	var watcher, listener, repo, channel = setup()
+	defer cleanup(watcher, repo)
 
-	watcher.Check(path, channel)
-	assert.Equal(t, 0, len(listener.paths))
+	watcher.Check(repo, channel)
+	assert.Equal(t, 0, len(listener.repos))
 
-	test_helpers.WriteFile(t, path, "test.md", "Hello")
-	watcher.Check(path, channel)
-	assert.Equal(t, 1, len(listener.paths))
-	assert.Equal(t, path, listener.paths[0])
+	test_helpers.WriteFile(t, repo, "test.md", "Hello")
+	watcher.Check(repo, channel)
+	assert.Equal(t, 1, len(listener.repos))
+	assert.Equal(t, repo, listener.repos[0])
 
-	commit(t, path)
+	commit(t, repo)
 
-	watcher.Check(path, channel)
-	assert.Equal(t, 1, len(listener.paths))
-	assert.Equal(t, path, listener.paths[0])
+	watcher.Check(repo, channel)
+	assert.Equal(t, 1, len(listener.repos))
+	assert.Equal(t, repo, listener.repos[0])
 
-	test_helpers.WriteFile(t, path, "test.md", "Hello2")
-	watcher.Check(path, channel)
-	assert.Equal(t, 2, len(listener.paths))
-	assert.Equal(t, path, listener.paths[0])
-	assert.Equal(t, path, listener.paths[1])
+	test_helpers.WriteFile(t, repo, "test.md", "Hello2")
+	watcher.Check(repo, channel)
+	assert.Equal(t, 2, len(listener.repos))
+	assert.Equal(t, repo, listener.repos[0])
+	assert.Equal(t, repo, listener.repos[1])
 
-	commit(t, path)
+	commit(t, repo)
 
 	// No change
-	test_helpers.WriteFile(t, path, "test.md", "Hello2")
-	watcher.Check(path, channel)
-	assert.Equal(t, 2, len(listener.paths))
+	test_helpers.WriteFile(t, repo, "test.md", "Hello2")
+	watcher.Check(repo, channel)
+	assert.Equal(t, 2, len(listener.repos))
 }


### PR DESCRIPTION
This changeset allows the config files to specify a non-master branch, and updates all git operations to work with that. "master" is the default branch used if one isn't specified.

All the tests have been updated for the new behaviour. Plus the tests now pass on case-insensitive filesystems like macos. NOTE: The actual behaviour on such filesystems is still not correct for renaming operations where only the filename case is changed. TODO: Is there a git flag for handling such stuff. 

